### PR TITLE
Add VS Code helper configs for DayZ modding

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,13 @@
+{
+    "configurations": [
+        {
+            "name": "DayZ Modding",
+            "includePath": [
+                "${workspaceFolder}/ce_sdk"
+            ],
+            "defines": [],
+            "intelliSenseMode": "windows-msvc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/dayz.code-snippets
+++ b/.vscode/dayz.code-snippets
@@ -1,0 +1,12 @@
+{
+    "DayZ Config Class": {
+        "prefix": "dayzclass",
+        "body": [
+            "class ${1:ClassName}",
+            "{",
+            "    ${0}",
+            "};"
+        ],
+        "description": "Estrutura básica de classe de config do DayZ"
+    }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "jmdayztools.jm-dayztools",
+        "jmdayztools.dayz-ce-schema"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "*.c": "cpp",
+        "*.cpp": "cpp"
+    },
+    "editor.snippetSuggestions": "top"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,62 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build DayZ Mods",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-ExecutionPolicy", "Bypass",
+                "-File", "${workspaceFolder}\\scripts\\build_mods.ps1"
+            ],
+            "options": {
+                "env": {
+                    "DAYZ_TOOLS": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\DayZ Tools",
+                    "DAYZ_MOD_OUTPUT": "${workspaceFolder}\\@BananaMod"
+                }
+            },
+            "problemMatcher": [],
+            "group": "build",
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Validate DayZ Mods",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-ExecutionPolicy", "Bypass",
+                "-File", "${workspaceFolder}\\scripts\\validate_mods.ps1"
+            ],
+            "options": {
+                "env": {
+                    "DAYZ_TOOLS": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\DayZ Tools"
+                }
+            },
+            "problemMatcher": [],
+            "group": "test",
+            "presentation": {
+                "reveal": "always"
+            }
+        },
+        {
+            "label": "Launch DayZ",
+            "type": "shell",
+            "command": "powershell",
+            "args": [
+                "-ExecutionPolicy", "Bypass",
+                "-File", "${workspaceFolder}\\scripts\\start_dayz.ps1"
+            ],
+            "options": {
+                "env": {
+                    "DAYZ_GAME": "C:\\Program Files (x86)\\Steam\\steamapps\\common\\DayZ"
+                }
+            },
+            "problemMatcher": [],
+            "presentation": {
+                "reveal": "always"
+            }
+        }
+    ]
+}

--- a/ce_sdk/README.md
+++ b/ce_sdk/README.md
@@ -1,0 +1,6 @@
+# DayZ Script Stubs
+
+Este diretório contém alguns arquivos de código de exemplo apenas para
+melhorar o IntelliSense do VS Code.
+É recomendável copiar para cá os scripts originais do jogo se você tiver acesso
+à instalação do DayZ (subpasta `\Scripts`).

--- a/ce_sdk/dayz_api_stub.c
+++ b/ce_sdk/dayz_api_stub.c
@@ -1,0 +1,15 @@
+class PlayerBase
+{
+    void Message(string msg);
+    EntityAI GetInventory();
+};
+
+class EntityAI
+{
+    void Delete();
+};
+
+class ItemBase : EntityAI
+{
+    void SetQuantity(float value);
+};

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,34 @@
 # Banana Mod
 
-Este repositório contém um mod simples para **DayZ** que adiciona um item de "Banana". Como não há um modelo 3D de banana disponível, o item reutiliza o modelo do pacote de arroz do próprio jogo.
+Este repositório contém um mod simples para **DayZ** que adiciona um item de "Banana". Como não há um modelo 3D de banana disponível, o item reutiliza o modelo do pacote de arroz do próprio jogo, mas inclui textura e som personalizados.
 
 ## Estrutura
 - **meta.cpp** e **mod.cpp**: arquivos de metadados do mod.
 - **Addons/**: contém subdiretórios por categoria (ex.: `Food`, `Weapons`, `Clothes`, `Objects`).
-  - **Addons/Food/Banana/**: definição do item de comida e arquivos de som e textura.
+ - **Addons/Food/Banana/**: definição do item de comida e arquivos de som e textura personalizados.
 
 ## Geração do PBO
 Para utilizar o mod no jogo, compile o diretório `Addons/Food/Banana` em um arquivo PBO utilizando o DayZ Tools (Addon Builder).
+
+## Compilação com VS Code
+Uma maneira prática de compilar todos os mods é utilizando a tarefa **Build DayZ Mods** definida em `.vscode/tasks.json`.
+
+1. Ajuste as variáveis de ambiente `DAYZ_TOOLS` (pasta de instalação do DayZ Tools) e `DAYZ_MOD_OUTPUT` (diretório onde os PBOs serão gerados). Elas podem ser configuradas diretamente no arquivo `tasks.json` ou no sistema operacional.
+2. Execute a tarefa `Build DayZ Mods` no VS Code (``Ctrl+Shift+B``) para compilar todos os subdiretórios de `Addons` que possuam um `config.cpp`.
+
+O script `scripts/build_mods.ps1` é responsável por chamar o **Addon Builder** para cada mod encontrado.
+
+Além da tarefa de build, o arquivo `.vscode/tasks.json` inclui:
+
+- **Validate DayZ Mods**: executa `scripts/validate_mods.ps1` para validar a sintaxe de todos os `config.cpp`.
+- **Launch DayZ**: inicia o executável do jogo definido na variável `DAYZ_GAME`.
+
+## Ambiente no VS Code
+
+O diretório `.vscode` também possui configurações pensadas para facilitar o desenvolvimento de mods:
+
+- `extensions.json` recomenda instalar as extensões **jm-dayztools** e **DayZ CE Schema**;
+- `c_cpp_properties.json` aponta para a pasta `ce_sdk` que contém stubs básicos de classes e métodos do jogo;
+- `dayz.code-snippets` disponibiliza um snippet simples para criação de classes de config.
+
+Se você tiver acesso aos scripts originais do DayZ, copie-os para `ce_sdk` para obter um IntelliSense mais completo.

--- a/scripts/build_mods.ps1
+++ b/scripts/build_mods.ps1
@@ -1,0 +1,33 @@
+param(
+    [string]$ToolsPath = $env:DAYZ_TOOLS,
+    [string]$OutDir    = $env:DAYZ_MOD_OUTPUT
+)
+
+if (-not $ToolsPath -or -not (Test-Path $ToolsPath)) {
+    Write-Error "DayZ Tools not found. Set DAYZ_TOOLS environment variable or edit the script."
+    exit 1
+}
+
+if (-not $OutDir) {
+    Write-Error "Output directory not specified. Set DAYZ_MOD_OUTPUT environment variable or edit the script."
+    exit 1
+}
+
+$builder = Join-Path $ToolsPath 'Bin\AddonBuilder\AddonBuilder.exe'
+if (-not (Test-Path $builder)) {
+    Write-Error "AddonBuilder.exe not found in $ToolsPath"
+    exit 1
+}
+
+if (-not (Test-Path $OutDir)) {
+    New-Item -ItemType Directory -Path $OutDir | Out-Null
+}
+
+$root = Join-Path $PSScriptRoot '..\Addons'
+$modDirs = Get-ChildItem $root -Recurse -Directory | Where-Object { Test-Path (Join-Path $_.FullName 'config.cpp') }
+
+foreach ($dir in $modDirs) {
+    $name = Split-Path $dir -Leaf
+    Write-Host "Building $name"
+    & $builder $dir.FullName $OutDir -clear
+}

--- a/scripts/start_dayz.ps1
+++ b/scripts/start_dayz.ps1
@@ -1,0 +1,17 @@
+param(
+    [string]$GamePath = $env:DAYZ_GAME
+)
+
+if (-not $GamePath -or -not (Test-Path $GamePath)) {
+    Write-Error "DayZ game directory not found. Set DAYZ_GAME environment variable or edit the script."
+    exit 1
+}
+
+$exe = Join-Path $GamePath 'DayZ_x64.exe'
+if (-not (Test-Path $exe)) {
+    Write-Error "DayZ_x64.exe not found in $GamePath"
+    exit 1
+}
+
+Start-Process $exe
+

--- a/scripts/validate_mods.ps1
+++ b/scripts/validate_mods.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$ToolsPath = $env:DAYZ_TOOLS
+)
+
+if (-not $ToolsPath -or -not (Test-Path $ToolsPath)) {
+    Write-Error "DayZ Tools not found. Set DAYZ_TOOLS environment variable or edit the script."
+    exit 1
+}
+
+$cfgConvert = Join-Path $ToolsPath 'Bin\CfgConvert\CfgConvertFile.exe'
+if (-not (Test-Path $cfgConvert)) {
+    Write-Error "CfgConvertFile.exe not found in $ToolsPath"
+    exit 1
+}
+
+$root = Join-Path $PSScriptRoot '..\Addons'
+$configs = Get-ChildItem $root -Recurse -Filter 'config.cpp'
+
+foreach ($cfg in $configs) {
+    Write-Host "Validating $($cfg.FullName)"
+    & $cfgConvert $cfg.FullName | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Validation failed for $($cfg.FullName)"
+        exit $LASTEXITCODE
+    }
+}
+
+Write-Host 'All configs validated successfully.'
+


### PR DESCRIPTION
## Summary
- recommend VS Code extensions for DayZ modding
- add simple IntelliSense configuration that points to a local `ce_sdk` directory
- provide a minimal DayZ API stub and snippets
- document the new VS Code environment settings

## Testing
- `powershell -ExecutionPolicy Bypass -File scripts/validate_mods.ps1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6848f96ed080832ab2eaad78019c118a